### PR TITLE
Fix typo in book title, update book URL

### DIFF
--- a/obtaining.xml
+++ b/obtaining.xml
@@ -147,11 +147,11 @@
         Amazon</url>.
 
         </p><p>
-	German: <em>Erlang/OTP (Plattform für massiv-parallele
-	und fehlertolerante System)</em> (Pavlo Baron) can be ordered
+	German: <em>Erlang/OTP (Plattform fÃ¼r massiv-parallele
+	und fehlertolerante Systeme)</em> (Pavlo Baron) can be ordered
 	directly from the <url
-	href='https://www.opensourcepress.de/index.php?26&amp;tt_products=327'>publisher</url>
-	or via Amazon.  </p><p>
+	href='http://www.opensourcepress.de/de/produkte/Erlang/OTP/150/978-3-941841-45-1'>publisher</url>
+	or via Amazon.</p><p>
 
 	</p><p> Spanish: <em>Erlang/OTP Un Mundo Concurrente</em>
 	(Manuel Rubio) can be ordered directly from the <url


### PR DESCRIPTION
As stated above, I fixed a typo in the book title of "Erlang/OTP (Plattform für massiv-parallele und fehlertolerante Systeme)" and updated the book's URL.

Furthermore, the German version of the website of Open Source Press (http://www.opensourcepress.de/de/) states that the publisher went out of business and the books cannot be purchased directly from them any more.

I'd suggest to keep the publisher link for reference and add a link to alternate ordering options (Amazon etc).
