### PR TITLE
Update QNX port info

### DIFF
--- a/implementations.xml
+++ b/implementations.xml
@@ -176,7 +176,7 @@
 		MacOS X.
 		</p><p>
 
-	<em>QNX</em>: Vlad Dumitrescu has looked
+	<em>QNX</em>: Some people may be looking
 		at porting to QNX. If you're interested, ask on the
 		erlang mailing list.</p><p>
 


### PR DESCRIPTION
The info was old and no longer accurate. There are others that are working with it.