### PR TITLE
update rebar link

### DIFF
--- a/libraries.xml
+++ b/libraries.xml
@@ -163,7 +163,7 @@
 
 <p>
   The most popular way of doing that is to use
-  <url href='https://github.com/rebar/rebar'>rebar</url>.
+  <url href='https://github.com/erlang/rebar3'>rebar</url>.
 </p>
 
 <p>


### PR DESCRIPTION
The FAQ links to rebar which is deprecated. I changed the link to rebar3.